### PR TITLE
install json_object_iterator.h header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(JSON_C_PUBLIC_HEADERS
     ./json_c_version.h
     ./json_inttypes.h
     ./json_object.h
+    ./json_object_iterator.h
     ./json_pointer.h
     ./json_tokener.h
     ./json_util.h


### PR DESCRIPTION
When building the project using cmake then installing it.  The
definitions in `json_object_iterator.h` are required but not installed
by the cmake install rule.  This patch adds the `json_object_iterator.h`
file to the list of files to install.

Signed-off-by: Keith Holman <keith.holman@windriver.com>